### PR TITLE
fix python3 import 的方式

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.pyc
 *.swp
 .idea/
+build/
+*.egg-info/

--- a/MANIFEST
+++ b/MANIFEST
@@ -4,4 +4,3 @@ setup.py
 cache/__init__.py
 cache/lru_cache.py
 cache/ommited.py
-cache/tests.py

--- a/cache/__init__.py
+++ b/cache/__init__.py
@@ -1,1 +1,1 @@
-from lru_cache import LruCache
+from .lru_cache import LruCache

--- a/cache/lru_cache.py
+++ b/cache/lru_cache.py
@@ -4,7 +4,7 @@ import time
 from collections import OrderedDict
 from threading import RLock
 
-from cache.ommited import OmittedType
+from .ommited import OmittedType
 
 
 class LruCache(object):

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,8 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='lru_cache',
-    version='0.2.3',
+    version='0.2.4',
     author='acmerfight',
     author_email='acmerfight@gmail.com',
     packages=['cache'],

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -3,7 +3,8 @@ import random
 import time
 import threading
 import unittest
-from lru_cache import LruCache
+
+from cache import LruCache
 
 
 class TesLruCache(unittest.TestCase):
@@ -66,7 +67,7 @@ class TesLruCache(unittest.TestCase):
             a.append(num)
             return num
 
-        for i in xrange(10):
+        for i in range(10):
             threading.Thread(target=foo, args=(i, )).start()
 
         main_thread = threading.currentThread()
@@ -92,7 +93,7 @@ class TesLruCache(unittest.TestCase):
             b.append(num)
             return num + 1
 
-        for i in xrange(10):
+        for i in range(10):
             threading.Thread(target=foo, args=(i, )).start()
             threading.Thread(target=bar, args=(i, )).start()
 


### PR DESCRIPTION
1. 
改为
```
from .lru_cache import LruCache
```

```
from .ommited import OmittedType
```
2. 将 tests.py 移到 tests 目录
3. setup 使用 setuptools 的

在本地
```
python3 setup.py test
python setup.py test
```

均 ok



